### PR TITLE
fix: update image repository paths in deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  BACKEND_IMAGE: ${{ github.repository }}/backend
-  FRONTEND_IMAGE: ${{ github.repository }}/frontend
+  BACKEND_IMAGE: ${{ github.repository_owner }}/pingaroo/backend
+  FRONTEND_IMAGE: ${{ github.repository_owner }}/pingaroo/frontend
 
 jobs:
   build-and-push:


### PR DESCRIPTION
This pull request updates the deployment workflow configuration to use the repository owner's namespace for Docker image references.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L10-R11): Updated `BACKEND_IMAGE` and `FRONTEND_IMAGE` environment variables to reference images under the `pingaroo` namespace using `${{ github.repository_owner }}` instead of `${{ github.repository }}`.