### PR TITLE
feat: update deployment configuration to use lowercase repository own…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Set lowercase repository owner
+        run: |
+          echo "REPO_OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -44,14 +48,18 @@ jobs:
         with:
           context: ./backend
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:${{ github.sha }},${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/pingaroo/backend:${{ github.sha }},${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/pingaroo/backend:latest
+          build-args: |
+            REPO_OWNER=${{ env.REPO_OWNER }}
 
       - name: Build and push Frontend
         uses: docker/build-push-action@v5
         with:
           context: ./frontend
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:${{ github.sha }},${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE }}:latest
+          tags: ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/pingaroo/frontend:${{ github.sha }},${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/pingaroo/frontend:latest
+          build-args: |
+            REPO_OWNER=${{ env.REPO_OWNER }}
 
   deploy:
     needs: build-and-push
@@ -59,6 +67,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set lowercase repository owner
+        run: |
+          echo "REPO_OWNER=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Create deployment directory
         uses: appleboy/ssh-action@v1.0.3
@@ -89,8 +101,8 @@ jobs:
           script: |
             cd /opt/pingaroo
             echo "REGISTRY=${{ env.REGISTRY }}" > .env
-            echo "BACKEND_IMAGE=${{ env.BACKEND_IMAGE }}" >> .env
-            echo "FRONTEND_IMAGE=${{ env.FRONTEND_IMAGE }}" >> .env
+            echo "BACKEND_IMAGE=${{ env.REPO_OWNER }}/pingaroo/backend" >> .env
+            echo "FRONTEND_IMAGE=${{ env.REPO_OWNER }}/pingaroo/frontend" >> .env
             echo "IMAGE_TAG=${{ github.sha }}" >> .env
             docker-compose pull
             docker-compose up -d 


### PR DESCRIPTION
This pull request updates the `.github/workflows/deploy.yml` file to enhance the deployment workflow by introducing the use of a lowercase repository owner (`REPO_OWNER`) and updating image tagging and build arguments for Docker. These changes improve consistency and flexibility in handling repository-specific configurations.

### Workflow Enhancements:

* **Set lowercase repository owner (`REPO_OWNER`)**:
  - Added a step to define `REPO_OWNER` as a lowercase version of `github.repository_owner` and store it in the environment variables. This step is included in both the `build-and-push` and `deploy` jobs. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R35-R38) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R71-R74)

* **Docker image tagging updates**:
  - Updated Docker image tags to include the `REPO_OWNER` in the path for both backend and frontend images. This ensures the images are uniquely associated with the repository owner.

* **Docker build arguments**:
  - Added `REPO_OWNER` as a build argument for both backend and frontend Docker builds to pass repository-specific information to the build context.

* **Environment file updates for deployment**:
  - Modified the `.env` file generation to use `REPO_OWNER` in the backend and frontend image paths, ensuring consistency with the updated tagging convention.