### PR TITLE
feat: update frontend port mapping and enhance Nginx proxy headers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   frontend:
     image: ${REGISTRY}/${FRONTEND_IMAGE}:${IMAGE_TAG:-latest}
     ports:
-      - "80:80"
+      - "8081:80"
     depends_on:
       - backend
     networks:

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -15,5 +15,8 @@ server {
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 } 


### PR DESCRIPTION
This pull request includes updates to the `docker-compose.yml` file and the Nginx configuration to improve port configuration and enhance proxy headers for better request handling and debugging.

### Port configuration update:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L16-R16): Changed the frontend service's port mapping from `80:80` to `8081:80` to avoid potential conflicts with other services running on port 80.

### Proxy header enhancements:
* [`frontend/nginx.conf`](diffhunk://#diff-5fbe9ea2846896111dc8e2e9b6aca7ca7bf9addea72461a4457581fadc49e5bdR18-R20): Added `X-Real-IP`, `X-Forwarded-For`, and `X-Forwarded-Proto` headers to the Nginx configuration to pass client information through the proxy, improving traceability and compatibility with upstream services.